### PR TITLE
chore : Optimize Docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.venv/
+__pycache__/
+*.pyc
+# 모델 캐시 폴더도 제외 (선택 사항)
+~/.cache/torch/hub/
+~/.cache/huggingface/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,37 @@
-# 1. 베이스 이미지 선택
-# 파이썬 3.11 버전의 가볍고 효율적인 slim 버전을 기반으로 이미지를 만듭니다.
-FROM python:3.11-slim
+# --- Stage 1: Builder ---
+# 라이브러리를 설치하고 빌드하는 전용 공간입니다.
+FROM python:3.11-slim as builder
 
-# 2. 작업 디렉토리 설정
-# 컨테이너 내에서 명령어가 실행될 기본 경로를 /app으로 설정합니다.
+# 작업 디렉토리 설정
 WORKDIR /app
 
-# 3. 의존성 설치
-# 먼저 requirements.txt 파일만 복사하여 라이브러리를 설치합니다.
-# 이렇게 하면 소스 코드가 변경될 때마다 매번 라이브러리를 새로 설치하는 비효율을 막을 수 있습니다.
+# 가상환경 생성 (패키지들을 격리하여 관리하기 위함)
+RUN python -m venv /app/venv
+ENV PATH="/app/venv/bin:$PATH"
+
+# 의존성 설치
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# 4. 소스 코드 복사
-# 현재 디렉토리(로컬)의 모든 파일을 컨테이너의 /app 디렉토리로 복사합니다.
+
+# --- Stage 2: Final Image ---
+# 실제 애플리케이션을 실행할 최종 이미지입니다.
+FROM python:3.11-slim
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# Builder 스테이지에서 설치된 가상환경(라이브러리)만 복사해옵니다.
+COPY --from=builder /app/venv /app/venv
+
+# 소스 코드를 복사합니다.
 COPY . .
 
-# 5. 포트 노출
-# FastAPI 서버가 8000번 포트에서 실행될 것이므로, 컨테이너의 8000번 포트를 외부와 연결할 수 있도록 개방합니다.
+# 가상환경의 경로를 PATH에 추가
+ENV PATH="/app/venv/bin:$PATH"
+
+# 포트 노출
 EXPOSE 8000
 
-# 6. 서버 실행 명령어
-# 컨테이너가 시작될 때 uvicorn을 사용해 app/main.py 안의 app 객체를 실행합니다.
-# --host 0.0.0.0 옵션은 컨테이너 외부에서 접근 가능하도록 만듭니다.
+# 서버 실행 명령어
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  ai-server:
+    build: .
+    container_name: my-ai-server
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch
+torchvision
+torchaudio
+
 fastapi
 uvicorn[standard]
 python-dotenv


### PR DESCRIPTION
## Overview
 - This PR addresses the issue of the excessively large Docker image size, which was previously over 7 GB. 
 - By implementing several optimization best practices, the final image size has been successfully reduced to approximately 1.9 GB.
## Completed Work
 - **Added `.dockerignore` file:** A `.dockerignore` file has been added to the repository root to exclude unnecessary files and directories (e.g., `.venv`, `__pycache__`) from the build context, preventing them from being copied into the image.

- **Refactored `Dockerfile` to Multi-Stage Build:** The `Dockerfile` has been rewritten to use a multi-stage build pattern.
    - The `builder` stage is now responsible for installing all Python dependencies into an isolated virtual environment.
    - The final, lightweight stage copies only the necessary application code and the prepared virtual environment from the `builder`, discarding all intermediate build files and caches.

- **Optimized PyTorch Dependency:** The `requirements.txt` file was updated to explicitly install the CPU-only version of PyTorch. This is the most significant change, as it prevents the inclusion of large, unnecessary CUDA (GPU) libraries in the final image.

## issue
- close #6 