### PR TITLE
feat : Implement full end-to-end chatbot integration

### DIFF
--- a/app/api/v1/endpoints/chat.py
+++ b/app/api/v1/endpoints/chat.py
@@ -16,10 +16,12 @@ def startup_event():
         )
 
 
-@router.post("/chat", response_model=ChatResponse)
+@router.post("/completions", response_model=ChatResponse)
 def chat_with_rag(request: ChatRequest):
     # 서비스 함수가 이제 딕셔너리를 반환합니다.
     result = get_rag_answer(request)
+
+    print(f"DEBUG: Returning from AI Server: {result}")
 
     # 딕셔너리의 각 키를 ChatResponse 모델에 맞게 전달합니다.
     return ChatResponse(

--- a/app/api/v1/endpoints/chat.py
+++ b/app/api/v1/endpoints/chat.py
@@ -18,7 +18,10 @@ def startup_event():
 
 @router.post("/chat", response_model=ChatResponse)
 def chat_with_rag(request: ChatRequest):
-    # 수정: get_rag_answer 함수 호출
-    final_answer = get_rag_answer(request)
+    # 서비스 함수가 이제 딕셔너리를 반환합니다.
+    result = get_rag_answer(request)
 
-    return ChatResponse(answer=final_answer)
+    # 딕셔너리의 각 키를 ChatResponse 모델에 맞게 전달합니다.
+    return ChatResponse(
+        answer=result["answer"], recommended_ids=result["recommended_ids"]
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,9 @@
 from fastapi import FastAPI
 from app.api.v1.endpoints import chat
 
-app = FastAPI()
+app = FastAPI(title="AI Server")
 
-app.include_router(chat.router, prefix="/api/v1")
+app.include_router(chat.router, prefix="/api/v1/chat", tags=["Chat"])
 
 
 @app.get("/")

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from typing import List
 
 
 class ChatRequest(BaseModel):
@@ -7,3 +8,4 @@ class ChatRequest(BaseModel):
 
 class ChatResponse(BaseModel):
     answer: str
+    recommended_ids: List[str]

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -84,6 +84,16 @@ def initialize_vector_store():
     RAG_CHAIN = create_retrieval_chain(retriever, document_chain)
 
 
-def get_rag_answer(request: ChatRequest) -> str:
+def get_rag_answer(request: ChatRequest) -> dict:  # <-- 반환 타입을 dict로 변경
+    """
+    사용자의 쿼리를 받아 RAG 파이프라인을 실행하고 최종 답변과 ID를 반환합니다.
+    """
     response = RAG_CHAIN.invoke({"input": request.query})
-    return response["answer"]
+
+    # 검색된 문서에서 product_id(source)를 추출합니다.
+    retrieved_ids = [doc.metadata["source"] for doc in response["context"]]
+
+    # 중복을 제거하여 유니크한 ID만 남깁니다.
+    unique_ids = list(dict.fromkeys(retrieved_ids))
+
+    return {"answer": response["answer"], "recommended_ids": unique_ids}

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -78,7 +78,7 @@ def initialize_vector_store():
             ("human", "{input}"),
         ]
     )
-    llm = ChatOpenAI(model="gpt-3.5-turbo")
+    llm = ChatOpenAI(model="gpt-4o")
     retriever = VECTOR_STORE.as_retriever(search_kwargs={"k": 3})
     document_chain = create_stuff_documents_chain(llm, prompt)
     RAG_CHAIN = create_retrieval_chain(retriever, document_chain)


### PR DESCRIPTION
## Overview
- This is a major feature PR that completes the full end-to-end integration of the RAG chatbot system. 
- It connects the three separate services—`front-end` (React), `back-end` (Java), and `ai-server` (Python)—into a single, cohesive, and fully functional application orchestrated by Docker Compose.
## Completed Work
This PR includes significant updates across all parts of the stack:

#### **System & DevOps:**
- The main `back-end/docker-compose.yml` has been updated to build and run the entire backend stack (`java-app`, `ai-server`, `mysql`, `redis`, etc.) with a single command.
- The Java application (`app`) has been containerized with its own `Dockerfile`.

#### **`back-end` (Java):**
- Implemented the public-facing API endpoint (`POST /api/users/me/chat`) in `ChatController`.
- Created `ChatService` to orchestrate the full request lifecycle: receiving the client request, calling the AI server via `WebClient`, and assembling the final response.
- Added a full set of DTOs for type-safe communication between all services.
- Implemented and configured Spring Security to correctly handle CORS pre-flight requests from the frontend, resolving the browser-specific API call failures.

#### **`front-end` (React):**
- Refactored the API call logic into a dedicated `src/api/chat.ts` module using a shared `axios` instance.
- Updated the `ChatWidget.tsx` component's `handleSendMessage` function to be asynchronous, call the backend API, and handle loading/error states.
- Integrated authentication by reading the JWT from a `.env` file and passing it in the `Authorization` header.
- Correctly configured the `vite.config.ts` proxy to forward `/api` requests to the Java backend, resolving path and connection issues.

## issue
- close #14 